### PR TITLE
게시글 목록 이미지 관련 수정

### DIFF
--- a/src/main/java/com/credential/cubrism/server/posts/model/PostImages.java
+++ b/src/main/java/com/credential/cubrism/server/posts/model/PostImages.java
@@ -22,4 +22,7 @@ public class PostImages {
 
     @Column(name = "image_url", nullable = false)
     private String imageUrl;
+
+    @Column(name = "image_index", nullable = false)
+    private int imageIndex;
 }

--- a/src/main/java/com/credential/cubrism/server/posts/service/PostService.java
+++ b/src/main/java/com/credential/cubrism/server/posts/service/PostService.java
@@ -66,6 +66,7 @@ public class PostService {
             PostImages postImages = new PostImages();
             postImages.setPost(post);
             postImages.setImageUrl(imageUrl);
+            postImages.setImageIndex(imageUrls.indexOf(imageUrl));
             postImageList.add(postImages);
         }
 
@@ -106,7 +107,11 @@ public class PostService {
                         post.getPostId(),
                         post.getBoard().getBoardName(),
                         post.getUser().getNickname(),
-                        post.getPostImages().isEmpty() ? null : post.getPostImages().get(0).getImageUrl(),
+                        post.getPostImages().stream()
+                                .filter(image -> image.getImageIndex() == 0)
+                                .findFirst()
+                                .map(PostImages::getImageUrl)
+                                .orElse(null),
                         post.getTitle(),
                         post.getContent(),
                         post.getCreatedDate().toString()


### PR DESCRIPTION
db에 이미지 url 저장시에 이미지 순서를 저장하도록 하고 게시글 목록을 불러올 때 이미지 순서 index값이 0인 이미지의 url을 반환하도록 수정