### PR TITLE
이미지 업로드 코드 분할 (게시글, 프로필)

### DIFF
--- a/src/main/java/com/credential/cubrism/server/authentication/service/ProfileImageService.java
+++ b/src/main/java/com/credential/cubrism/server/authentication/service/ProfileImageService.java
@@ -1,67 +1,26 @@
 package com.credential.cubrism.server.authentication.service;
 
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.credential.cubrism.server.authentication.model.Users;
 import com.credential.cubrism.server.authentication.repository.UserRepository;
 import com.credential.cubrism.server.authentication.utils.AuthenticationUtil;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import com.credential.cubrism.server.common.utils.ProfileImageUploadUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.util.Objects;
 import java.util.UUID;
 
 @Service
+@RequiredArgsConstructor
 public class ProfileImageService {
-    private final AmazonS3 s3;
-    private final String bucketName;
     private final UserRepository userRepository;
+    private final ProfileImageUploadUtil profileImageUploadUtil;
 
-    private final static long MAX_FILE_SIZE = 10 * 1024 * 1024;
-    private final static String filePath = "profile_images/";
-
-    @Autowired
-    public ProfileImageService(AmazonS3 s3, @Value("${cloud.aws.s3.bucket}") String bucketName, UserRepository userRepository) {
-        this.s3 = s3;
-        this.bucketName = bucketName;
-        this.userRepository = userRepository;
-    }
-
-    public String uploadProfileImage(MultipartFile file, Authentication authentication) throws IOException {
-        String fileType = file.getContentType();
+    public String uploadProfileImage(MultipartFile file, Authentication authentication) {
         Users user = AuthenticationUtil.getUserFromAuthentication(authentication, userRepository);
-        UUID uuid = user.getUuid();
+        UUID userId = user.getUuid();
 
-        if (file.getSize() > MAX_FILE_SIZE) { // 파일의 크기를 10MB로 제한
-            throw new RuntimeException("10MB 이하의 이미지만 업로드 가능합니다");
-        }
-
-        if (!Objects.requireNonNull(fileType).startsWith("image")) { // MIME 타입을 image로 제한
-            throw new RuntimeException("이미지 파일만 업로드 가능합니다");
-        }
-
-        String originalFileName = file.getOriginalFilename(); // 원본 파일명
-        String extension = Objects.requireNonNull(originalFileName).substring(originalFileName.lastIndexOf(".")); // 파일 확장자
-
-        // S3 버킷에 해당 uuid로 저장된 파일이 있으면 삭제
-        ObjectListing objectListing = s3.listObjects(bucketName, filePath + uuid.toString());
-        for (S3ObjectSummary objectSummary : objectListing.getObjectSummaries()) {
-            s3.deleteObject(bucketName, objectSummary.getKey());
-        }
-
-        String fileName = filePath + uuid + extension; // 파일 이름
-
-        ObjectMetadata metadata = new ObjectMetadata(); // 파일 메타데이터
-        metadata.setContentLength(file.getSize()); // 파일 크기
-        metadata.setContentType(fileType); // 파일 MIME 타입
-
-        s3.putObject(bucketName, fileName, file.getInputStream(), metadata); // S3 버킷에 파일 업로드
-        return s3.getUrl(bucketName, fileName).toString();
+        return profileImageUploadUtil.uploadImage(file, userId);
     }
 }

--- a/src/main/java/com/credential/cubrism/server/common/utils/ProfileImageUploadUtil.java
+++ b/src/main/java/com/credential/cubrism/server/common/utils/ProfileImageUploadUtil.java
@@ -1,0 +1,83 @@
+package com.credential.cubrism.server.common.utils;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Objects;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileImageUploadUtil {
+    private final AmazonS3 s3;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    private final static long MAX_FILE_SIZE = 10;
+    private final static String filePath = "profile_images/";
+
+    public String uploadImage(MultipartFile file, UUID userId) {
+        validateFile(file); // 파일 유효성 검사
+        return uploadImageToS3(file, userId); // 파일 업로드
+    }
+
+    private void validateFile(MultipartFile file) {
+        String originalFileName = file.getOriginalFilename();
+        String fileType;
+
+        try {
+            fileType = Files.probeContentType(Paths.get(Objects.requireNonNull(originalFileName)));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("MIME 타입을 확인할 수 없습니다");
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE * 1024 * 1024) {
+            throw new IllegalArgumentException(MAX_FILE_SIZE + "MB 이하의 이미지만 업로드 가능합니다");
+        }
+
+        if (!Objects.requireNonNull(fileType).startsWith("image")) {
+            throw new IllegalArgumentException("이미지 파일만 업로드 가능합니다");
+        }
+    }
+
+    private String uploadImageToS3(MultipartFile file, UUID userId) {
+        String fileName = getImageName(file, userId);
+        removePreviousImage(userId);
+        uploadImage(file, fileName);
+        return s3.getUrl(bucketName, fileName).toString();
+    }
+
+    private String getImageName(MultipartFile file, UUID userId) {
+        String originalFileName = Objects.requireNonNull(file.getOriginalFilename());
+        String extension = originalFileName.substring(originalFileName.lastIndexOf("."));
+        return filePath + userId + extension;
+    }
+
+    private void removePreviousImage(UUID userId) {
+        ObjectListing objectListing = s3.listObjects(bucketName, filePath + userId.toString());
+        for (S3ObjectSummary objectSummary : objectListing.getObjectSummaries()) {
+            s3.deleteObject(bucketName, objectSummary.getKey());
+        }
+    }
+
+    private void uploadImage(MultipartFile file, String fileName) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+        metadata.setContentType(file.getContentType());
+
+        try {
+            s3.putObject(bucketName, fileName, file.getInputStream(), metadata);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("이미지 업로드에 실패했습니다");
+        }
+    }
+}

--- a/src/main/java/com/credential/cubrism/server/posts/controller/PostController.java
+++ b/src/main/java/com/credential/cubrism/server/posts/controller/PostController.java
@@ -1,7 +1,7 @@
 package com.credential.cubrism.server.posts.controller;
 
 import com.credential.cubrism.server.common.dto.ErrorDTO;
-import com.credential.cubrism.server.posts.dto.PostRegisterPostDTO;
+import com.credential.cubrism.server.posts.dto.PostAddPostDTO;
 import com.credential.cubrism.server.posts.dto.PostResultDTO;
 import com.credential.cubrism.server.posts.dto.PostUpdatePostDTO;
 import com.credential.cubrism.server.posts.service.PostService;
@@ -23,14 +23,14 @@ import java.util.List;
 public class PostController {
     private final PostService postService;
 
-    @PostMapping("/register")
-    public ResponseEntity<?> registerPost(
+    @PostMapping("/add")
+    public ResponseEntity<?> addPost(
             @RequestPart("file") List<MultipartFile> files,
-            @RequestPart("data") PostRegisterPostDTO dto,
+            @RequestPart("data") PostAddPostDTO dto,
             Authentication authentication
     ) {
         try {
-            postService.registerPost(files, dto, authentication);
+            postService.addPost(files, dto, authentication);
             return ResponseEntity.ok().body(new PostResultDTO(true, null));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new PostResultDTO(false, e.getMessage()));
@@ -41,11 +41,12 @@ public class PostController {
 
     @PostMapping("/update")
     public ResponseEntity<?> updatePost(
-            @RequestPart("post") PostUpdatePostDTO dto,
+            @RequestPart("file") List<MultipartFile> files,
+            @RequestPart("data") PostUpdatePostDTO dto,
             Authentication authentication
     ) {
         try {
-            postService.updatePost(dto, authentication);
+            postService.updatePost(files, dto, authentication);
             return ResponseEntity.ok().body(new PostResultDTO(true, null));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new PostResultDTO(false, e.getMessage()));

--- a/src/main/java/com/credential/cubrism/server/posts/dto/PostAddPostDTO.java
+++ b/src/main/java/com/credential/cubrism/server/posts/dto/PostAddPostDTO.java
@@ -3,7 +3,7 @@ package com.credential.cubrism.server.posts.dto;
 import lombok.Getter;
 
 @Getter
-public class PostRegisterPostDTO {
+public class PostAddPostDTO {
     private String boardName;
     private String title;
     private String content;

--- a/src/main/java/com/credential/cubrism/server/posts/model/Posts.java
+++ b/src/main/java/com/credential/cubrism/server/posts/model/Posts.java
@@ -43,7 +43,7 @@ public class Posts {
 
     @LastModifiedDate
     @Column(name = "modified_date", nullable = false)
-    private LocalDateTime updatedDate;
+    private LocalDateTime modifiedDate;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<PostImages> postImages;


### PR DESCRIPTION
이미지 업로드 관련해서는 수정이 필요할듯.
지금은 이미지를 클라이언트->서버->S3 순서로 업로드를 하다 보니 시간이 오래 걸려서 signed url을 통해 클라이언트에서 S3로 바로 업로드 하는 방식으로 바꾸는걸 고려중